### PR TITLE
Add unique css handle to each stack item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Unique css handle to the stack items.
 
 ## [0.0.2] - 2019-12-05
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Use this layout component to show blocks on top of other blocks.
 
 Each children passed to `stack-layout` will receive an increasingly higher value of `zIndex`.
 
-This means `flex-layout.row#viewone` will appear on the bottom, `flex-layout.row#viewtwo` will appear over it with `zIndex` of value 2, and `flex-layout.row#viewthree` will appear over them both with `zIndex` of value 3.
+This means `flex-layout.row#viewone` will appear on the bottom, `flex-layout.row#viewtwo` will appear over it with `zIndex` of value 2, and `flex-layout.row#viewthree` will appear over them both with `zIndex` of value 3. Another thing to notice is that you pass the `blockClass` prop to any children of the `stack-layout` it will apply the `blockClass` to the element that wraps child element.
 
 ## Configuration
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -8,16 +8,27 @@ interface Props {
   zIndexOffset?: number
 }
 
-const StackLayout: StorefrontFunctionComponent<Props> = ({ children, zIndexOffset = 0 }) => {
+const StackLayout: StorefrontFunctionComponent<Props> = ({
+  children,
+  zIndexOffset = 0,
+}) => {
   const handles = useCssHandles(CSS_HANDLES)
   return (
     <div className={`${handles.stackContainer} relative`}>
       {React.Children.toArray(children).map((child, idx) => {
+
+        // This allows the user customize the stackItem via CSS, via the blockClass of each child
+        const childBlockClass = (child as any)?.props?.blockProps?.blockClass || ''
+        let stackItemBlockClass = ''
+        if (childBlockClass) {
+          stackItemBlockClass = applyModifiers(handles.stackItem, childBlockClass)
+        }
+
         if (idx === 0) {
           return (
             <div
               key={idx}
-              className={applyModifiers(handles.stackItem, 'first')}
+              className={`${applyModifiers(handles.stackItem, 'first')} ${stackItemBlockClass}`}
               style={{ zIndex: zIndexOffset + 1 }}
             >
               {child}
@@ -28,7 +39,7 @@ const StackLayout: StorefrontFunctionComponent<Props> = ({ children, zIndexOffse
         return (
           <div
             key={idx}
-            className={`${handles.stackItem} absolute top-0 left-0 w-auto h-auto`}
+            className={`${handles.stackItem} absolute top-0 left-0 w-auto h-auto ${stackItemBlockClass}`}
             style={{ zIndex: zIndexOffset + idx + 1 }}
           >
             {child}


### PR DESCRIPTION
With the current behavior, there is no way to position each element in the stack, with this handle you can do it now.

See the preview button in this [workspace](https://quickview--storecomponents.myvtex.com/)

![image](https://user-images.githubusercontent.com/8517023/73393030-b87ffd00-42b9-11ea-90df-f3e39ca1db81.png)


### Extra information

Since the stack will never change position because is passed by the store theme the index will always be the same for all the component lifecycle