### PR TITLE
fix: add role="region" to stack layout div with aria-label for WCAG 2.2 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add `role="region"` to stack layout div with aria-label to comply with WCAG 2.2 Level A (4.1.2) and ARIA 1.2 specification
 
 ## [0.1.3] - 2025-08-11
   + ### Fixed

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -16,7 +16,7 @@ const StackLayout: StorefrontFunctionComponent<Props> = ({
   const handles = useCssHandles(CSS_HANDLES)
   const intl = useIntl()
   return (
-    <div className={`${handles.stackContainer} relative`} aria-label={arialabel ? arialabel : intl.formatMessage(
+    <div className={`${handles.stackContainer} relative`} role="region" aria-label={arialabel ? arialabel : intl.formatMessage(
       { id: 'store/stack-layout.aria-label' })}>
       {React.Children.toArray(children).map((child, idx) => {
 


### PR DESCRIPTION
## What does this PR do?

Adds `role="region"` to the stack layout `<div>` that contains `aria-label`, fixing an accessibility violation identified in an external audit for the kohlerqa account.

## Why is this needed?

The current implementation uses `aria-label` on a `<div>` without an explicit `role` attribute. According to the ARIA 1.2 specification, `aria-label` is a **prohibited attribute** on elements with the implicit `role="generic"` (the default for `<div>` elements).

This violates:
- **WCAG 2.2 Level A** - Criterion 4.1.2 (Name, Role, Value)
- **ARIA 1.2** specification - aria-label prohibited on generic role elements

## How does this fix it?

By adding `role="region"`, the element becomes a proper landmark that:
- Accepts accessible names via `aria-label`
- Is semantically appropriate for layout sections
- Complies with ARIA 1.2 and WCAG 2.2 Level A standards

## What changed?

### Files modified:
- `react/index.tsx` - Added `role="region"` to the main stack layout div
- `CHANGELOG.md` - Added entry for this fix

## Testing

This change maintains backward compatibility and does not affect functionality - it only improves accessibility compliance.

## Related PRs
- stack-layout#16 (previous partial fix - added aria-label)
- vtex-apps/flex-layout#75 (equivalent fix applied to flex-layout)

## References
- [ARIA 1.2 - Prohibited aria-* attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-label)
- [WCAG 2.2 - 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)